### PR TITLE
[TUI] Improve visibility of keys labels to interact with logs in the home screen

### DIFF
--- a/tui/views/home.js
+++ b/tui/views/home.js
@@ -82,13 +82,13 @@ export class HomeView extends BaseView {
       top: 7,
       left: '100%-35',
       content: '[l] View log',
-      style: {fg: 'gray'}
+      style: {fg: 'green'}
     }))
     screen.append(blessed.text({
       top: 7,
       left: '100%-20',
       content: '[e] View err log',
-      style: {fg: 'gray'}
+      style: {fg: 'green'}
     }))
     
     screen.render()


### PR DESCRIPTION
It took me a while to see the log options in the TUI's home screen.
They live in the top right corner and are gray like the logs.

Currently keys in the menu are otherwise green.
This change make the key elements more coherent.

Before
![ctzn_before](https://user-images.githubusercontent.com/80153024/110205674-67095080-7e71-11eb-9bad-815d4cceafcb.png)

After
![ctzn_after](https://user-images.githubusercontent.com/80153024/110205677-6bce0480-7e71-11eb-9d8b-b1560b384cd1.png)
