### PR TITLE
Server plugins

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -9,7 +9,7 @@ import * as table from './table.js'
 import * as users from './users.js'
 import * as view from './view.js'
 
-export function setup (wsServer, config) {
+export function setup (wsServer, config, extensions) {
   wsServer.wss.on('connection', function connection(ws, req) {
 
     // Save request headers onto the ws client for later
@@ -60,4 +60,11 @@ export function setup (wsServer, config) {
   // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
   // - *Note*: With dbMethods, views and schemas, will likely not need this for normal
   //           plugins but may be needed for advanced ones.
+  if (extensions) {
+    const apiExtensions = Array.from(extensions).map((extension) => Object.values(extension.default.apiExtensions)).flat().filter(Boolean)
+    for (let apiExtension of apiExtensions) {
+      //TODO: extensions.setupApi(wsServer, config)
+      apiExtension(wsServer, config)
+    }
+  }
 }

--- a/api/index.js
+++ b/api/index.js
@@ -51,4 +51,13 @@ export function setup (wsServer, config) {
   table.setup(wsServer, config)
   users.setup(wsServer, config)
   view.setup(wsServer, config)
+
+  // setup any plugins here:
+  // - call #setupApi on each plugin
+  // - expose:
+  //    - wsServer
+  //    - config
+  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+  // - *Note*: With dbMethods, views and schemas, will likely not need this for normal
+  //           plugins but may be needed for advanced ones.
 }

--- a/api/index.js
+++ b/api/index.js
@@ -52,19 +52,10 @@ export function setup (wsServer, config, extensions) {
   users.setup(wsServer, config)
   view.setup(wsServer, config)
 
-  // setup any plugins here:
-  // - call #setupApi on each plugin
-  // - expose:
-  //    - wsServer
-  //    - config
-  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-  // - *Note*: With dbMethods, views and schemas, will likely not need this for normal
-  //           plugins but may be needed for advanced ones.
   if (extensions) {
-    const apiExtensions = Array.from(extensions).map((extension) => Object.values(extension.default.apiExtensions)).flat().filter(Boolean)
-    for (let apiExtension of apiExtensions) {
-      //TODO: extensions.setupApi(wsServer, config)
-      apiExtension(wsServer, config)
+    const apiExtensions = Array.from(extensions).map((extension) => extension.default.apiExtensions).flat().filter(Boolean)
+    for (let extension of apiExtensions) {
+      extension.setup(wsServer, config)
     }
   }
 }

--- a/bin.js
+++ b/bin.js
@@ -21,7 +21,8 @@ const match = subcommand({
           domain: args.domain,
           configDir: args.configDir,
           hyperspaceHost: args.hyperspaceHost,
-          hyperspaceStorage: args.hyperspaceStorage
+          hyperspaceStorage: args.hyperspaceStorage,
+          extensions: args.extensions || ''
         })
       }
     },
@@ -35,7 +36,8 @@ const match = subcommand({
           simulateHyperspace: true,
           port: args.port,
           configDir: args.configDir,
-          domain: args.domain
+          domain: args.domain,
+          extensions: args.extensions || ''
         })
       }
     },

--- a/db/citizen.js
+++ b/db/citizen.js
@@ -3,9 +3,10 @@ import * as perf from '../lib/perf.js'
 
 
 export class PublicCitizenDB extends BaseHyperbeeDB {
-  constructor (userId, key) {
+  constructor (userId, key, extensions) {
     super(`public:${userId}`, key)
     this.userId = userId
+    this.extensions = extensions
   }
 
   get dbType () {
@@ -32,17 +33,25 @@ export class PublicCitizenDB extends BaseHyperbeeDB {
   // - call #setupPublicCitizenDb on each plugin
   // - expose required internal methods:
   //    - this
-  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+  // - expose db, dbGetters, errors, util.js, perf.js, strings.js, network.js from ctzn package
   // - Note: Likely only for advanced cases.
+    if (this.extensions) {
+      const publicCitizenDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.publicCitizenDbExtensions)).flat().filter(Boolean)
+      for (let dbExtension of publicCitizenDbExtensions) {
+        //TODO: extensions.setupPublicCitizenDb(this)
+        dbExtension(this)
+      }
+    }
   }
 }
 
 export class PrivateCitizenDB extends BaseHyperbeeDB {
-  constructor (userId, key, publicServerDb, publicDb) {
+  constructor (userId, key, publicServerDb, publicDb, extensions) {
     super(`private:${userId}`, key, {isPrivate: true})
     this.userId = userId
     this.publicServerDb = publicServerDb
     this.publicDb = publicDb
+    this.extensions = extensions
   }
 
   get dbType () {
@@ -58,5 +67,12 @@ export class PrivateCitizenDB extends BaseHyperbeeDB {
   //    - this
   // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
   // - Note: Likely only for advanced cases.
+    if (this.extensions) {
+      const privateCitizenDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.privateCitizenDbExtensions)).flat().filter(Boolean)
+      for (let dbExtension of privateCitizenDbExtensions) {
+        //TODO: extensions.setupPrivateCitizenDb(this)
+        dbExtension(this, { perf })
+      }
+    }
   }
 }

--- a/db/citizen.js
+++ b/db/citizen.js
@@ -27,6 +27,13 @@ export class PublicCitizenDB extends BaseHyperbeeDB {
     this.memberships.onDel(() => this.emit('subscriptions-changed'))
     this.follows.onPut(() => this.emit('subscriptions-changed'))
     this.follows.onDel(() => this.emit('subscriptions-changed'))
+
+  // setup any plugins here:
+  // - call #setupPublicCitizenDb on each plugin
+  // - expose required internal methods:
+  //    - this
+  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+  // - Note: Likely only for advanced cases.
   }
 }
 
@@ -44,5 +51,12 @@ export class PrivateCitizenDB extends BaseHyperbeeDB {
 
   async setup () {
     await super.setup()
+
+  // setup any plugins here:
+  // - call #setupPrivateCitizenDb on each plugin
+  // - expose required internal methods:
+  //    - this
+  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+  // - Note: Likely only for advanced cases.
   }
 }

--- a/db/citizen.js
+++ b/db/citizen.js
@@ -1,7 +1,6 @@
 import { BaseHyperbeeDB } from './base.js'
 import * as perf from '../lib/perf.js'
 
-
 export class PublicCitizenDB extends BaseHyperbeeDB {
   constructor (userId, key, extensions) {
     super(`public:${userId}`, key)
@@ -29,17 +28,10 @@ export class PublicCitizenDB extends BaseHyperbeeDB {
     this.follows.onPut(() => this.emit('subscriptions-changed'))
     this.follows.onDel(() => this.emit('subscriptions-changed'))
 
-  // setup any plugins here:
-  // - call #setupPublicCitizenDb on each plugin
-  // - expose required internal methods:
-  //    - this
-  // - expose db, dbGetters, errors, util.js, perf.js, strings.js, network.js from ctzn package
-  // - Note: Likely only for advanced cases.
     if (this.extensions) {
-      const publicCitizenDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.publicCitizenDbExtensions)).flat().filter(Boolean)
-      for (let dbExtension of publicCitizenDbExtensions) {
-        //TODO: extensions.setupPublicCitizenDb(this)
-        dbExtension(this)
+      const publicCitizenDbExtensions = Array.from(this.extensions).map((extension) => extension.default.publicCitizenDbExtensions).flat().filter(Boolean)
+      for (let extension of publicCitizenDbExtensions) {
+        extension.setup(this)
       }
     }
   }
@@ -61,17 +53,10 @@ export class PrivateCitizenDB extends BaseHyperbeeDB {
   async setup () {
     await super.setup()
 
-  // setup any plugins here:
-  // - call #setupPrivateCitizenDb on each plugin
-  // - expose required internal methods:
-  //    - this
-  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-  // - Note: Likely only for advanced cases.
     if (this.extensions) {
-      const privateCitizenDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.privateCitizenDbExtensions)).flat().filter(Boolean)
-      for (let dbExtension of privateCitizenDbExtensions) {
-        //TODO: extensions.setupPrivateCitizenDb(this)
-        dbExtension(this, { perf })
+      const privateCitizenDbExtensions = Array.from(this.extensions).map((extension) => extension.default.privateCitizenDbExtensions).flat().filter(Boolean)
+      for (let extension of privateCitizenDbExtensions) {
+        extension.setup(this, { perf })
       }
     }
   }

--- a/db/community.js
+++ b/db/community.js
@@ -45,17 +45,10 @@ export class PublicCommunityDB extends BaseHyperbeeDB {
     this.members.onPut(() => this.emit('subscriptions-changed'))
     this.members.onDel(() => this.emit('subscriptions-changed'))
 
-    // setup any plugins here:
-    // - call #setupCommunityDb on each plugin
-    // - expose required internal methods:
-    //    - this
-    // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-    // - Note: Likely only for advanced cases.
     if (this.extensions) {
-      const publicCommunityDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.publicCommunityDbExtensions)).flat().filter(Boolean)
-      for (let dbExtension of publicCommunityDbExtensions) {
-        //TODO: extensions.setupPublicCommunity(this)
-        dbExtension(this)
+      const publicCommunityDbExtensions = Array.from(this.extensions).map((extension) => extension.default.publicCommunityDbExtensions).flat().filter(Boolean)
+      for (let extension of publicCommunityDbExtensions) {
+        extension.setup(this)
       }
     }
   }

--- a/db/community.js
+++ b/db/community.js
@@ -1,9 +1,10 @@
 import { BaseHyperbeeDB } from './base.js'
 
 export class PublicCommunityDB extends BaseHyperbeeDB {
-  constructor (userId, key) {
+  constructor (userId, key, extensions) {
     super(`public:${userId}`, key)
     this.userId = userId
+    this.extensions = extensions
   }
 
   get dbType () {
@@ -50,5 +51,12 @@ export class PublicCommunityDB extends BaseHyperbeeDB {
     //    - this
     // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
     // - Note: Likely only for advanced cases.
+    if (this.extensions) {
+      const publicCommunityDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.publicCommunityDbExtensions)).flat().filter(Boolean)
+      for (let dbExtension of publicCommunityDbExtensions) {
+        //TODO: extensions.setupPublicCommunity(this)
+        dbExtension(this)
+      }
+    }
   }
 }

--- a/db/community.js
+++ b/db/community.js
@@ -43,5 +43,12 @@ export class PublicCommunityDB extends BaseHyperbeeDB {
 
     this.members.onPut(() => this.emit('subscriptions-changed'))
     this.members.onDel(() => this.emit('subscriptions-changed'))
+
+    // setup any plugins here:
+    // - call #setupCommunityDb on each plugin
+    // - expose required internal methods:
+    //    - this
+    // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+    // - Note: Likely only for advanced cases.
   }
 }

--- a/db/index.js
+++ b/db/index.js
@@ -27,10 +27,9 @@ export let privateServerDb = undefined
 export let publicDbs = new CaseInsensitiveMap()
 export let privateDbs = new CaseInsensitiveMap()
 
-export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simulateHyperspace, extensions = []}) {
+export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simulateHyperspace}, extensions = []) {
   await hyperspace.setup({hyperspaceHost, hyperspaceStorage, simulateHyperspace})
   _extensions = extensions
-  // add included server plugins
   await schemas.setup(_extensions)
 
   _configDir = configDir

--- a/db/index.js
+++ b/db/index.js
@@ -19,6 +19,7 @@ import { UnknownUserTypeIssue } from '../lib/issues/unknown-user-type.js'
 import lock from '../lib/lock.js'
 
 let _configDir = undefined
+let _extensions = undefined
 export let configPath = undefined
 export let config = undefined
 export let publicServerDb = undefined
@@ -26,20 +27,21 @@ export let privateServerDb = undefined
 export let publicDbs = new CaseInsensitiveMap()
 export let privateDbs = new CaseInsensitiveMap()
 
-export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simulateHyperspace}) {
+export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simulateHyperspace, extensions = []}) {
   await hyperspace.setup({hyperspaceHost, hyperspaceStorage, simulateHyperspace})
+  _extensions = extensions
   // add included server plugins
-  await schemas.setup()
+  await schemas.setup(_extensions)
 
   _configDir = configDir
   configPath = path.join(configDir, 'dbconfig.json')
   await readDbConfig()
 
-  publicServerDb = new PublicServerDB(constructUserId('server'), config.publicServer)
+  publicServerDb = new PublicServerDB(constructUserId('server'), config.publicServer, _extensions)
   await publicServerDb.setup()
   publicDbs.set(publicServerDb.userId, publicServerDb)
   publicServerDb.watch(onDatabaseChange)
-  privateServerDb = new PrivateServerDB(config.privateServer, publicServerDb)
+  privateServerDb = new PrivateServerDB(config.privateServer, publicServerDb, _extensions)
   await privateServerDb.setup()
   privateDbs.set(publicServerDb.userId, privateServerDb)
 
@@ -48,7 +50,7 @@ export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simu
   await saveDbConfig()
 
   // add included server plugins
-  views.setup()
+  views.setup(_extensions)
   await loadMemberUserDbs()
   await loadOrUnloadExternalUserDbs()
   /* dont await */ catchupAllIndexes()
@@ -88,19 +90,19 @@ export async function createUser ({type, username, email, password, profile}) {
     let publicDb
     let privateDb
     if (type === 'citizen') {
-      publicDb = new PublicCitizenDB(userId, null)
+      publicDb = new PublicCitizenDB(userId, null, _extensions)
       await publicDb.setup()
       publicDb.watch(onDatabaseChange)
       publicDb.on('subscriptions-changed', loadOrUnloadExternalUserDbs)
       await catchupIndexes(publicDb)
       user.dbUrl = publicDb.url
 
-      privateDb = new PrivateCitizenDB(userId, null, publicServerDb, publicDb)
+      privateDb = new PrivateCitizenDB(userId, null, publicServerDb, publicDb, _extensions)
       await privateDb.setup()
       await catchupIndexes(privateDb)
       account.privateDbUrl = privateDb.url
     } else if (type === 'community') {
-      publicDb = new PublicCommunityDB(userId, null)
+      publicDb = new PublicCommunityDB(userId, null, _extensions)
       await publicDb.setup()
       publicDb.watch(onDatabaseChange)
       publicDb.on('subscriptions-changed', loadOrUnloadExternalUserDbs)
@@ -200,14 +202,14 @@ async function loadMemberUserDbs () {
         console.error('Skipping db load due to duplicate userId', userId)
         return
       }
-      let publicDb = new PublicCitizenDB(userId, hyperUrlToKey(user.value.dbUrl))
+      let publicDb = new PublicCitizenDB(userId, hyperUrlToKey(user.value.dbUrl), _extensions)
       await publicDb.setup()
       publicDbs.set(userId, publicDb)
       publicDb.watch(onDatabaseChange)
       publicDb.on('subscriptions-changed', loadOrUnloadExternalUserDbs)
 
       let accountEntry = await privateServerDb.accounts.get(user.value.username)
-      let privateDb = new PrivateCitizenDB(userId, hyperUrlToKey(accountEntry.value.privateDbUrl), publicServerDb, publicDb)
+      let privateDb = new PrivateCitizenDB(userId, hyperUrlToKey(accountEntry.value.privateDbUrl), publicServerDb, publicDb, _extensions)
       await privateDb.setup()
       privateDbs.set(userId, privateDb)
       privateDb.on('subscriptions-changed', loadOrUnloadExternalUserDbs)
@@ -219,7 +221,7 @@ async function loadMemberUserDbs () {
         console.error('Skipping db load due to duplicate userId', userId)
         return
       }
-      let publicDb = new PublicCommunityDB(userId, hyperUrlToKey(user.value.dbUrl))
+      let publicDb = new PublicCommunityDB(userId, hyperUrlToKey(user.value.dbUrl), _extensions)
       await publicDb.setup()
       publicDbs.set(userId, publicDb)
       publicDb.watch(onDatabaseChange)
@@ -318,11 +320,11 @@ async function loadDbByType (userId, dbUrl) {
   const dbDesc = await bee.get('_db', {wait: true, timeout: 60e3})
   if (!dbDesc) throw new Error('Failed to load database description')
   if (dbDesc.value?.dbType === 'ctzn.network/public-citizen-db') {
-    return new PublicCitizenDB(userId, key)
+    return new PublicCitizenDB(userId, key, _extensions)
   } else if (dbDesc.value?.dbType === 'ctzn.network/public-community-db') {
-    return new PublicCommunityDB(userId, key)
+    return new PublicCommunityDB(userId, key, _extensions)
   } else if (dbDesc.value?.dbType === 'ctzn.network/public-server-db') {
-    return new PublicServerDB(userId, key)
+    return new PublicServerDB(userId, key, _extensions)
   }
   throw new Error(`Unknown database type: ${dbDesc.value?.dbType}`)
 }

--- a/db/index.js
+++ b/db/index.js
@@ -28,8 +28,9 @@ export let privateDbs = new CaseInsensitiveMap()
 
 export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simulateHyperspace}) {
   await hyperspace.setup({hyperspaceHost, hyperspaceStorage, simulateHyperspace})
+  // add included server plugins
   await schemas.setup()
-  
+
   _configDir = configDir
   configPath = path.join(configDir, 'dbconfig.json')
   await readDbConfig()
@@ -46,6 +47,7 @@ export async function setup ({configDir, hyperspaceHost, hyperspaceStorage, simu
   config.privateServer = privateServerDb.key.toString('hex')
   await saveDbConfig()
 
+  // add included server plugins
   views.setup()
   await loadMemberUserDbs()
   await loadOrUnloadExternalUserDbs()
@@ -109,7 +111,7 @@ export async function createUser ({type, username, email, password, profile}) {
     await publicServerDb.users.put(username, user)
     if (type === 'citizen') await privateServerDb.accounts.put(username, account)
     await onDatabaseChange(publicServerDb, [privateServerDb])
-    
+
     publicDbs.set(userId, publicDb)
     if (privateDb) {
       privateDbs.set(userId, privateDb)
@@ -316,9 +318,9 @@ async function loadDbByType (userId, dbUrl) {
   const dbDesc = await bee.get('_db', {wait: true, timeout: 60e3})
   if (!dbDesc) throw new Error('Failed to load database description')
   if (dbDesc.value?.dbType === 'ctzn.network/public-citizen-db') {
-    return new PublicCitizenDB(userId, key) 
+    return new PublicCitizenDB(userId, key)
   } else if (dbDesc.value?.dbType === 'ctzn.network/public-community-db') {
-    return new PublicCommunityDB(userId, key) 
+    return new PublicCommunityDB(userId, key)
   } else if (dbDesc.value?.dbType === 'ctzn.network/public-server-db') {
     return new PublicServerDB(userId, key)
   }
@@ -394,7 +396,7 @@ async function loadExternalDbInner (userId) {
     await privateServerDb.userDbIdx.put(dbUrl, {dbUrl, userId})
   } catch (e) {
     issues.add(new LoadExternalUserDbIssue({userId, cause: 'Failed to update our DNS-ID -> URL database', error: e}))
-    return false    
+    return false
   }
 
   return publicDb

--- a/db/server.js
+++ b/db/server.js
@@ -254,7 +254,7 @@ export class PublicServerDB extends BaseHyperbeeDB {
         }
       }
     })
-    
+
     this.createIndexer('ctzn.network/feed-idx', ['ctzn.network/post'], async (batch, db, diff) => {
       if (diff.left || !diff.right) return // ignore edits and deletes
       if (!diff.right.value.community) {
@@ -340,7 +340,7 @@ export class PublicServerDB extends BaseHyperbeeDB {
             }
           }
         }
-  
+
         if (diff.right) {
           let i = -1
           if (reactionsIdxEntry.value.reactions[diff.right.value.reaction]) {
@@ -361,7 +361,7 @@ export class PublicServerDB extends BaseHyperbeeDB {
             }
           }
         }
-  
+
         await batch.put(this.reactionsIdx.constructBeeKey(reactionsIdxEntry.key), reactionsIdxEntry.value)
       } finally {
         release()
@@ -370,7 +370,7 @@ export class PublicServerDB extends BaseHyperbeeDB {
 
     this.createIndexer('ctzn.network/owned-items-idx', ['ctzn.network/item'], async (batch, db, diff) => {
       const pend = perf.measure(`publicDb:owned-items-indexer`)
-      
+
       const newOwner = diff.right?.value?.owner
       const oldOwner = diff.left?.value?.owner
       if (newOwner?.dbUrl === oldOwner?.dbUrl) {
@@ -401,6 +401,15 @@ export class PublicServerDB extends BaseHyperbeeDB {
         pend()
       }
     })
+
+
+  // setup any plugins here:
+  // - call #setupPublicServerDb on each plugin
+  // - expose required internal methods:
+  //    - this
+  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+  // - Note: Likely only for advanced plugins
+
   }
 
   async onDatabaseCreated () {
@@ -413,7 +422,7 @@ export class PublicServerDB extends BaseHyperbeeDB {
       .map(db => db.url)
       .concat([this.url]) // index self
   }
-} 
+}
 
 export class PrivateServerDB extends BaseHyperbeeDB {
   constructor (key, publicServerDb) {
@@ -451,13 +460,18 @@ export class PrivateServerDB extends BaseHyperbeeDB {
       }
     })
 
-    
+    // setup any plugins here:
+    // - call #setupPublicServerDb on each plugin
+    // - expose required internal methods:
+    //    - this
+    // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+    // - Note: Likely only for advanced plugins
   }
 
   async getSubscribedDbUrls () {
     return [this.publicServerDb.url]
   }
-  
+
   async onDatabaseCreated () {
     console.log('New private server database created, key:', this.key.toString('hex'))
   }

--- a/db/server.js
+++ b/db/server.js
@@ -403,18 +403,10 @@ export class PublicServerDB extends BaseHyperbeeDB {
       }
     })
 
-
-    // setup any plugins here:
-    // - call #setupPublicServerDb on each plugin
-    // - expose required internal methods:
-    //    - this
-    // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-    // - Note: Likely only for advanced plugins
     if (this.extensions) {
-      const publicServerDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.publicCommunityDbExtensions)).flat().filter(Boolean)
-      for (let dbExtension of publicServerDbExtensions) {
-        //TODO: extensions.setupPublicServerDb(this)
-        dbExtension(this, { dbGet, constructEntryUrl, perf, mlts })
+      const publicServerDbExtensions = Array.from(this.extensions).map((extension) => extension.default.publicServerDbExtensions).flat().filter(Boolean)
+      for (let extension of publicServerDbExtensions) {
+        extension.setup(this, { dbGet, constructEntryUrl, perf, mlts })
       }
     }
   }
@@ -468,17 +460,10 @@ export class PrivateServerDB extends BaseHyperbeeDB {
       }
     })
 
-    // setup any plugins here:
-    // - call #setupPublicServerDb on each plugin
-    // - expose required internal methods:
-    //    - this
-    // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-    // - Note: Likely only for advanced plugins
     if (this.extensions) {
-      const privateServerDbExtensions = Array.from(this.extensions).map((extension) => Object.values(extension.default.publicCommunityDbExtensions)).flat().filter(Boolean)
-      for (let dbExtension of privateServerDbExtensions) {
-        //TODO: extensions.setupPrivateServerDb(this)
-        dbExtension(this, { dbGet, constructEntryUrl, perf, mlts })
+      const privateServerDbExtensions = Array.from(this.extensions).map((extension) => extension.default.privateServerDbExtensions).flat().filter(Boolean)
+      for (let extension of privateServerDbExtensions) {
+        extension.setup(this, { dbGet, constructEntryUrl, perf, mlts })
       }
     }
   }

--- a/db/views.js
+++ b/db/views.js
@@ -45,7 +45,7 @@ export function setup () {
       userId = await fetchUserId(userId)
       userDb = db.publicDbs.get(userId)
       if (!userDb) throw 'Not found'
-      
+
       const ptr = await userDb.blobs.getPointer('avatar')
       if (!ptr) throw 'Not found'
 
@@ -75,7 +75,7 @@ export function setup () {
     userId = await fetchUserId(userId)
     const userDb = db.publicDbs.get(userId)
     if (!userDb) throw 'Not found'
-    
+
     const ptr = await userDb.blobs.getPointer(blobname)
     if (!ptr) throw 'Not found'
 
@@ -262,6 +262,14 @@ export function setup () {
   define('ctzn.network/thread-view', async (auth, url) => {
     return {comments: await dbGetters.getThread(url, auth)}
   })
+
+  // setup any plugins here:
+  // - call #setupViews on each plugin
+  // - expose required internal methods:
+  //    - define
+  //    - getDb
+  //    - getListOpts
+  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
 }
 
 // internal methods

--- a/db/views.js
+++ b/db/views.js
@@ -263,19 +263,10 @@ export function setup (extensions) {
     return {comments: await dbGetters.getThread(url, auth)}
   })
 
-  // setup any plugins here:
-  // - call #setupViews on each plugin
-  // - expose required internal methods:
-  //    - define
-  //    - getDb
-  //    - getListOpts
-  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-
   if (extensions) {
-    const dbViewExtensions = Array.from(extensions).map((extension) => Object.values(extension.default.dbViewExtensions)).flat().filter(Boolean)
-    for (let dbViewExtension of dbViewExtensions) {
-      //TODO: extensions.setupDbView({define, getDb, getListOpts})
-      dbViewExtension({define, getDb, getListOpts});
+    const dbViewExtensions = Array.from(extensions).map((extension) => extension.default.dbViewExtensions).flat().filter(Boolean)
+    for (let extension of dbViewExtensions) {
+      extension.setup({define, getDb, getListOpts});
     }
   }
 }

--- a/db/views.js
+++ b/db/views.js
@@ -38,7 +38,7 @@ export async function exec (schemaId, auth, ...args) {
   return res
 }
 
-export function setup () {
+export function setup (extensions) {
   define('ctzn.network/avatar-view', async (auth, userId) => {
     let userDb
     try {
@@ -270,6 +270,14 @@ export function setup () {
   //    - getDb
   //    - getListOpts
   // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+
+  if (extensions) {
+    const dbViewExtensions = Array.from(extensions).map((extension) => Object.values(extension.default.dbViewExtensions)).flat().filter(Boolean)
+    for (let dbViewExtension of dbViewExtensions) {
+      //TODO: extensions.setupDbView({define, getDb, getListOpts})
+      dbViewExtension({define, getDb, getListOpts});
+    }
+  }
 }
 
 // internal methods

--- a/index.js
+++ b/index.js
@@ -182,10 +182,9 @@ export async function start (opts) {
   })
 
   if (extensionModules) {
-    const appExtensions = Array.from(extensionModules).map((extensionModule) => Object.values(extensionModule.default.appExtensions)).flat().filter(Boolean)
-    for (let appExtension of appExtensions) {
-      // TODO: appExtension.setup(app)
-      appExtension(app)
+    const appExtensions = Array.from(extensionModules).map((extensionModule) => extensionModule.default.appExtensions).flat().filter(Boolean)
+    for (let extension of appExtensions) {
+      extension.setup(app)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -15,8 +15,15 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { fileURLToPath } from 'url'
 import * as os from 'os'
-import { setOrigin, getDomain, parseAcctUrl, usernameToUserId, DEBUG_MODE_PORTS_MAP } from './lib/strings.js'
+import * as stringHelpers from './lib/strings.js'
+import * as dbGetters from './db/getters.js'
+import * as dbHelpers from './db/util.js'
+import * as testHelpers from './tests/_util.js'
+import * as schemas from './lib/schemas.js'
+import * as networkHelpers from './lib/network.js'
+import * as errors from './lib/errors.js'
 
+const { setOrigin, getDomain, parseAcctUrl, usernameToUserId, DEBUG_MODE_PORTS_MAP } = stringHelpers;
 const PACKAGE_JSON_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), 'package.json')
 const PACKAGE_JSON = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'))
 
@@ -43,6 +50,10 @@ export async function start (opts) {
   app.set('views', path.join(path.dirname(fileURLToPath(import.meta.url)), 'views'))
   app.set('view engine', 'ejs')
   app.use(cors())
+
+  //load extensions
+  const extensions = config.extensions.split(',').filter(Boolean) || [];
+  const extensionModules = await Promise.all(extensions.map(async (extension) => await import(extension)));
 
   app.get('/', (req, res) => {
     res.render('index')
@@ -170,12 +181,20 @@ export async function start (opts) {
     }
   })
 
+  if (extensionModules) {
+    const appExtensions = Array.from(extensionModules).map((extensionModule) => Object.values(extensionModule.default.appExtensions)).flat().filter(Boolean)
+    for (let appExtension of appExtensions) {
+      // TODO: appExtension.setup(app)
+      appExtension(app)
+    }
+  }
+
   app.use((req, res) => {
     res.status(404).send('404 Page not found')
   })
 
   const wsServer = new WebSocketServer({noServer: true})
-  api.setup(wsServer, config)
+  api.setup(wsServer, config, extensionModules)
 
   const server = new http.Server(app)
   server.on('upgrade', (request, socket, head) => {
@@ -188,7 +207,7 @@ export async function start (opts) {
   })
 
   await email.setup(config)
-  await db.setup(config)
+  await db.setup(config, extensionModules)
 
   // process.on('SIGINT', close)
   // process.on('SIGTERM', close)
@@ -233,4 +252,21 @@ function getDb (username) {
   const publicDb = db.publicDbs.get(userId)
   if (!publicDb) throw new Error('User database not found')
   return publicDb
+}
+
+export {
+  api,
+  db,
+  dbGetters,
+  dbHelpers,
+  dbViews,
+  email,
+  errors,
+  getDb,
+  issues,
+  networkHelpers,
+  perf,
+  schemas,
+  stringHelpers,
+  testHelpers,
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -96,4 +96,8 @@ export class Config {
     try { fs.mkdirSync(this.configDir) } catch (e) {}
     fs.writeFileSync(this.filePath, JSON.stringify(this.values, null, 2), 'utf8')
   }
+
+  get extensions () {
+    return this.overrides.extensions || this.values.extensions || ''
+  }
 }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -25,7 +25,7 @@ export async function setup (extensions = []) {
   // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
 
   const coreSchemas = await loadCoreSchemas();
-  const extensionSchemas = extensions.map((extension) => Object.values(extension.default.schemas)).flat()
+  const extensionSchemas = Array.from(extensions || []).map((extension) => Object.values(extension.default.schemas)).flat()
   for (let schema of [...coreSchemas, ...extensionSchemas]) {
     try {
       if (!schema.id) throw new Error('No .id')

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -17,6 +17,13 @@ const schemas = new Map()
 export const get = schemas.get.bind(schemas)
 
 export async function setup () {
+  // setup any plugins here:
+  // - call #setupSchemas on each plugin
+  // - expose:
+  //    - schemas
+  //    - mlts
+  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
+
   const schemasPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schemas')
   const schemaFilenames = await fsp.readdir(schemasPath)
   for (let filename of schemaFilenames) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -17,13 +17,6 @@ const schemas = new Map()
 export const get = schemas.get.bind(schemas)
 
 export async function setup (extensions = []) {
-  // setup any plugins here:
-  // - call #setupSchemas on each plugin
-  // - expose:
-  //    - schemas
-  //    - mlts
-  // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
-
   const coreSchemas = await loadCoreSchemas();
   const extensionSchemas = Array.from(extensions || []).map((extension) => Object.values(extension.default.schemas)).flat()
   for (let schema of [...coreSchemas, ...extensionSchemas]) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -16,7 +16,7 @@ addFormats(ajv)
 const schemas = new Map()
 export const get = schemas.get.bind(schemas)
 
-export async function setup () {
+export async function setup (extensions = []) {
   // setup any plugins here:
   // - call #setupSchemas on each plugin
   // - expose:
@@ -24,20 +24,34 @@ export async function setup () {
   //    - mlts
   // - expose db, dbGetters, errors, util.js, strings.js, network.js from ctzn package
 
+  const coreSchemas = await loadCoreSchemas();
+  const extensionSchemas = extensions.map((extension) => Object.values(extension.default.schemas)).flat()
+  for (let schema of [...coreSchemas, ...extensionSchemas]) {
+    try {
+      if (!schema.id) throw new Error('No .id')
+      schemas.set(schema.id, new Schema(schema))
+    } catch (e) {
+      console.error('Failed to load schema', schema.id)
+      console.error(e)
+      process.exit(1)
+    }
+  }
+}
+
+async function loadCoreSchemas () {
   const schemasPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schemas')
   const schemaFilenames = await fsp.readdir(schemasPath)
-  for (let filename of schemaFilenames) {
+  return Promise.all(schemaFilenames.map(async (filename) => {
     try {
       const str = await fsp.readFile(path.join(schemasPath, filename), 'utf8')
-      const obj = JSON.parse(str)
-      if (!obj.id) throw new Error('No .id')
-      schemas.set(obj.id, new Schema(obj))
+      return JSON.parse(str);
     } catch (e) {
       console.error('Failed to load schema', filename)
       console.error(e)
       process.exit(1)
     }
-  }
+  })
+  )
 }
 
 export function createValidator (schema) {

--- a/tui/views/home.js
+++ b/tui/views/home.js
@@ -264,6 +264,7 @@ export class HomeView extends BaseView {
     header({label: 'Advanced'})
     input({label: 'Hyperspace Host', key: 'hyperspaceHost'})
     input({label: 'Hyperspace Storage Dir', key: 'hyperspaceStorage'})
+    input({label: 'Extensions', key: 'extensions'})
 
     inputs[0].focus()
     this.screen.saveFocus()


### PR DESCRIPTION
## What?

Proposal for extending ctzn servers via server plugins.

The server plugins (or extensions) are npm packages that can be enabled via configuration.

I created an example server plugin package here: https://github.com/saimonmoore/ctzn-server-plugin-example complete with actual examples of working code and passing tests.

See the readme of the example plugin for instructions on how to get it all setup.

The basic gist:

- There are a few entry points where plugins can insert and extend key parts of ctzn: `db classes`, `schemas`, `db views`, `api`, `app` etc
- Each package exports a public api of functions and each of these functions (save that of schemas) will have the `setup` method called on it.
- Certain helpers (network, strings), db, schema helpers etc are also now exported by the `ctzn` package. Ideally, these would be extracted into a ctzn-lib package (I envision `ctzn-lib`, `ctzn-db`, `ctzn-server` packages in the future).

**Note**: I've not actually published the package yet. Basically because I obviously want your feedback and this PR and any future changes required would need to be merged so the example server plugin can actually depend on a version of ctzn with support for server-plugins.

And tests are passing :)

Let me know what you think. I just rebased with your latest push.

## Next steps

If you are happy with the proposal and it eventually makes it way in, then I'll:

- publish the `ctzn-server-plugin-example` on npm
- Create another PR to add this package as a dependency to ctzn
- Write up some documentation to make it easy for others to get started with their own plugins.