### PR TITLE
add follows-only feed view

### DIFF
--- a/db/views.js
+++ b/db/views.js
@@ -7,7 +7,7 @@ import { fetchUserId } from '../lib/network.js'
 import * as dbGetters from './getters.js'
 import * as schemas from '../lib/schemas.js'
 import * as errors from '../lib/errors.js'
-import { listHomeFeed, listDbmethodFeed } from './feed-getters.js'
+import { listHomeFeed, listDbmethodFeed, listFollowsOnlyFeed } from './feed-getters.js'
 import { fetchNotications, countNotications, dbGet, fetchItemClass, fetchReactions, addPrefixToRangeOpts } from './util.js'
 
 const DEFAULT_USER_AVATAR_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'static', 'img', 'default-user-avatar.jpg')
@@ -178,6 +178,9 @@ export function setup () {
   })
 
   define('ctzn.network/feed-view', async (auth, opts) => {
+    if (!!opts.followOnly) {
+      return {feed: await listFollowsOnlyFeed(opts, auth)}
+    }
     return {feed: await listHomeFeed(opts, auth)}
   })
 


### PR DESCRIPTION
As a user, I have somewhat separate considerations for updates from individuals I follow vs. updates from communities. I would like to be able to separate these out in my feed. this provides an option to get only Follow updates.

as I type this up, it occurs to me that it would be nice to not filter out the community posts *by* follows, or at least not the ones for communities I am also in.